### PR TITLE
Add baseline resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment
+venv/
+
+# Data files
+/data/*.csv
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Particle Hunter is an experiment to detect Higgs Boson events in the CERN dataset. The project focuses on building an efficient classification model using the XGBoost algorithm with future support for Bayesian hyper-parameter optimization via Optuna.
 
+This repository now includes a lightweight training script and requirement listings to help you get started quickly.
+
 ## Dataset
 
 - **Source**: [Kaggle Higgs Boson Dataset](https://www.kaggle.com/competitions/higgs-boson/data)
@@ -36,5 +38,18 @@ pip install -r requirements.txt
 
 ## Usage
 
-Detailed training scripts will be provided in future updates. After installing dependencies and preparing the dataset, refer to forthcoming documentation for running experiments.
+1. Download `training.csv` from Kaggle and place it inside the `data/` directory.
+2. Install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Run the baseline training script:
+
+```bash
+python train.py
+```
+
+The script splits the dataset, trains an XGBoost model and reports the AUC score on the validation set.
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,5 @@
+# Data Directory
+
+Place the Higgs Boson training data here as `training.csv`.
+The file can be downloaded from the [Kaggle Higgs Boson Dataset](https://www.kaggle.com/competitions/higgs-boson/data).
+This repository does not include the dataset due to size and licensing constraints.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+numpy
+scikit-learn
+xgboost
+optuna

--- a/train.py
+++ b/train.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import roc_auc_score
+from xgboost import XGBClassifier
+
+
+def load_data(path='data/training.csv'):
+    df = pd.read_csv(path)
+    X = df.drop(['Label'], axis=1)
+    y = df['Label']
+    return train_test_split(X, y, test_size=0.2, random_state=42)
+
+
+def train_model(X_train, y_train):
+    model = XGBClassifier(
+        n_estimators=200,
+        learning_rate=0.1,
+        max_depth=6,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        eval_metric='auc'
+    )
+    model.fit(X_train, y_train)
+    return model
+
+
+def evaluate(model, X_test, y_test):
+    preds = model.predict_proba(X_test)[:, 1]
+    auc = roc_auc_score(y_test, preds)
+    print(f'AUC: {auc:.4f}')
+
+
+def main():
+    X_train, X_test, y_train, y_test = load_data()
+    model = train_model(X_train, y_train)
+    evaluate(model, X_test, y_test)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add common ignores for data and Python cache
- list required Python packages in `requirements.txt`
- add a minimal training script with XGBoost
- document where to put the dataset
- update README with usage instructions

## Testing
- `python -m py_compile train.py`


------
https://chatgpt.com/codex/tasks/task_e_685270eabe98832fbf668b0dc2707272